### PR TITLE
Inconsistency in the R2RMLTC0020a output.

### DIFF
--- a/test-cases/R2RMLTC0020a/mappeda.nq
+++ b/test-cases/R2RMLTC0020a/mappeda.nq
@@ -1,4 +1,4 @@
-<http://example.com/base/http%3A%2F%2Fexample.com%2Fcompany%2FAlice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+<http://example.com/base/http%3A%2F%2Fcompany.com%2FAlice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
 <http://example.com/base/Bob> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
 <http://example.com/base/Bob%2FCharles> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
 <http://example.com/base/path%2F..%2FDanny> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .


### PR DESCRIPTION
Hi, I noticed an inconsistency in the expected result of the test `R2RMLTC0020a`.
In the [HTML page of the test suite](https://www.w3.org/2001/sw/rdb2rdf/test-cases/#R2RMLTC0020a), the first subject is consistent with [content of the database](https://github.com/kg-construct/r2rml-implementation-report/blob/main/test-cases/databases/d020.sql) (and the mapping).

However [in the official output file](https://dvcs.w3.org/hg/rdb2rdf-tests/raw-file/default/D020-1table1column5rows/mappeda.nq), the first subject is incorrect.

Best,
Benjamin