### PR TITLE
config: use the correct data for the engine test date

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ paths:
         json-ld-context: >
           {
             "earl": "http://www.w3.org/ns/earl#",
-            "dcterms": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
             "doap": "http://usefulinc.com/ns/doap#",
             "rdb2rdftest": "http://purl.org/NET/rdb2rdf-test#",
             "foaf": "http://xmlns.com/foaf/0.1/",
@@ -66,7 +66,7 @@ paths:
             "version": "doap:release",
             "assertedBy": "earl:assertedBy",
             "fullname": "foaf:name",
-            "date": "doap:created",
+            "date": "dcterms:date",
             "homepage": "doap:homepage",
             "type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
           }


### PR DESCRIPTION
Creation date is not the same as test date.

According to prefix.cc, `http://purl.org/dc/elements/1.1/` and `http://purl.org/dc/terms/` are synonyms, but the `test.py` uses `http://purl.org/dc/terms/` instead of `http://purl.org/dc/elements/1.1/`.

Depending on what we want, we either accept this patch like it is, or change the `test.py` script to use the same IRI `http://purl.org/dc/elements/1.1/` so we don't need to add the prefix.


![image](https://user-images.githubusercontent.com/4999159/115214006-64ea1100-a102-11eb-84e3-8ccf8df8bf9d.png)
